### PR TITLE
Callbacks

### DIFF
--- a/proxy/callback.functions.php
+++ b/proxy/callback.functions.php
@@ -33,6 +33,9 @@ function civiproxy_callback_validate_body_xwwwformurlencoded($expected, $actual)
   //TODO
 }
 
+// For now, I have written this 'placeholder' method to pass on post requests.
+// Sparkpost says that it works OK. Might be a good idea to refactor/improve
+// civiproxy_redirect() instead/as well.
 function civiproxy_callback_redirect($target_path, $method) {
   switch ($method) {
     case 'POST':

--- a/proxy/callback.functions.php
+++ b/proxy/callback.functions.php
@@ -1,9 +1,13 @@
 <?php
 
 function civiproxy_callback_validate_request_method($expected, $actual){
-  if($expected != $actual){
-    civiproxy_http_error("Invalid request method.", 405);
+  if(is_array($expected) && in_array($actual, $expected)){
+    return;
   }
+  if(is_string($expected) && $expected == $actual){
+    return;
+  }
+  civiproxy_http_error("Invalid request method.", 405);
 }
 
 function civiproxy_callback_validate_content_type($expected, $actual){

--- a/proxy/callback.functions.php
+++ b/proxy/callback.functions.php
@@ -1,0 +1,66 @@
+<?php
+
+function civiproxy_callback_validate_request_method($expected, $actual){
+  if($expected != $actual){
+    civiproxy_http_error("Invalid request method.", 405);
+  }
+}
+
+function civiproxy_callback_validate_content_type($expected, $actual){
+  if($expected != $actual){
+    civiproxy_http_error("Forbidden content type.", 403);
+  }
+}
+
+function civiproxy_callback_validate_body($expected, $actual, $content_type){
+  switch ($content_type) {
+    case 'application/json':
+      civiproxy_callback_validate_body_json($expected, $actual);
+      break;
+    case 'application/x-www-form-urlencoded':
+      civiproxy_callback_validate_body_xwwwformurlencoded($expected, $actual);
+      break;
+    default:
+      civiproxy_http_error("Forbidden content type (expecting {$expected}).", 403);
+  }
+}
+
+function civiproxy_callback_validate_body_json($expected, $actual) {
+  //TODO
+}
+
+function civiproxy_callback_validate_body_xwwwformurlencoded($expected, $actual) {
+  //TODO
+}
+
+function civiproxy_callback_redirect($target_path, $method) {
+  switch ($method) {
+    case 'POST':
+      civiproxy_callback_redirect_post($target_path);
+      break;
+  }
+  exit;
+}
+
+// Change the URL, forward the body. Respond with the response
+function civiproxy_callback_redirect_post($target_path) {
+  global $target_civicrm;
+  $target_url = "$target_civicrm/{$target_path}";
+
+  $ch = curl_init();
+  curl_setopt($ch, CURLOPT_POST, 1);
+  curl_setopt($ch, CURLOPT_POSTFIELDS, file_get_contents('php://input'));
+  curl_setopt($ch, CURLOPT_URL, $target_url);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER,1);
+  curl_setopt($ch, CURLOPT_HEADER, 0);
+  $response = curl_exec($ch);
+  if (curl_error($ch)){
+    civiproxy_http_error("CURL error (" . curl_errno($ch) . ") ".curl_error($ch) , 501);
+  }
+
+  // I think that most callbacks just want a response code
+  http_response_code(curl_getinfo($ch, CURLINFO_HTTP_CODE));
+
+  // But some might be interested in the response.
+  echo $response;
+}

--- a/proxy/callback.php
+++ b/proxy/callback.php
@@ -1,0 +1,69 @@
+<?php
+// Handles callback URLs as follows:
+// 1. Validates callback
+// 2. Passes to civicrm if the payload passes validation
+// 2. Returns an appropriate response (an HTML code)
+// Note: valid callbacks should be defined as elements of a $callbacks variable
+// in config.php.
+// Callback URL should be configured in the service as follows:
+// "{$proxy_base}/callback.php?source={$callbacks[$key]}&secret={$callbacks[$key]['secret']}"
+// where $key is a key defined in the $callbacks variable in config.php.
+
+require_once "config.php";
+require_once "proxy.php";
+require_once "callback.functions.php";
+
+civiproxy_security_check('callback');
+
+if (!isset($callbacks_enabled) || $callbacks_enabled !==true){
+  civiproxy_http_error("Feature disabled", 403);
+}
+
+// Check that this callback has been defined
+parse_str($_SERVER['QUERY_STRING'], $query_params);
+if(isset($callbacks[$query_params['source']])){
+  //Retrieve definition from config
+  $definition = $callbacks[$query_params['source']];
+}else{
+  civiproxy_http_error("Undefined callback", 403);
+}
+
+// Check that a secret has been defined
+if(!isset($definition['secret'])){
+  civiproxy_http_error("No secret defined for this callback", 501);
+}
+
+// Check secret has been sent
+if(!isset($query_params['secret'])){
+  civiproxy_http_error("Secret missing from query parameters", 403);
+}
+
+// Check secret
+if(!isset($query_params['secret']) || $definition['secret'] !== $query_params['secret'] ){
+  civiproxy_http_error("Invalid secret", 403);
+}
+
+if(!in_array($_SERVER['REQUEST_METHOD'], ['POST'])){
+  civiproxy_http_error("Unsupported request method", 501);
+}
+
+// If a request method has been defined, validate it
+if(isset($definition['request_method'])){
+  civiproxy_callback_validate_request_method($definition['request_method'], $_SERVER['REQUEST_METHOD']);
+}
+
+// If a content type has been defined, validate it
+if(isset($definition['content_type'])){
+  civiproxy_callback_validate_content_type($definition['content_type'], $_SERVER['CONTENT_TYPE']);
+}
+
+// TODO? implement body validation
+if(isset($validator['body'])){
+  civiproxy_callback_validate_body($validator['body'], file_get_contents("php://input"), $_SERVER['CONTENT_TYPE']);
+}
+
+// We have passed all the validators, forward the request
+
+// TODO for now, I have written my own method to pass on post requests. Would be
+// better to refactor / improve civiproxy_redirect()
+civiproxy_callback_redirect($definition['target_path'], $_SERVER['REQUEST_METHOD']);

--- a/proxy/callback.php
+++ b/proxy/callback.php
@@ -44,7 +44,7 @@ if(!isset($query_params['secret']) || $definition['secret'] !== $query_params['s
 }
 
 // Check this is a supported request method
-if(!in_array($_SERVER['REQUEST_METHOD'], ['POST'])){
+if(!in_array($_SERVER['REQUEST_METHOD'], ['GET', 'POST'])){
   civiproxy_http_error("Unsupported request method", 501);
 }
 

--- a/proxy/callback.php
+++ b/proxy/callback.php
@@ -43,6 +43,7 @@ if(!isset($query_params['secret']) || $definition['secret'] !== $query_params['s
   civiproxy_http_error("Invalid secret", 403);
 }
 
+// Check this is a supported request method
 if(!in_array($_SERVER['REQUEST_METHOD'], ['POST'])){
   civiproxy_http_error("Unsupported request method", 501);
 }
@@ -50,6 +51,11 @@ if(!in_array($_SERVER['REQUEST_METHOD'], ['POST'])){
 // If a request method has been defined, validate it
 if(isset($definition['request_method'])){
   civiproxy_callback_validate_request_method($definition['request_method'], $_SERVER['REQUEST_METHOD']);
+}
+
+// Check this is a supported content type
+if(!in_array($_SERVER['CONTENT_TYPE'], ['application/json', 'application/x-www-form-urlencoded'])){
+  civiproxy_http_error("Unsupported content type", 501);
 }
 
 // If a content type has been defined, validate it
@@ -63,7 +69,4 @@ if(isset($validator['body'])){
 }
 
 // We have passed all the validators, forward the request
-
-// TODO for now, I have written my own method to pass on post requests. Would be
-// better to refactor / improve civiproxy_redirect()
 civiproxy_callback_redirect($definition['target_path'], $_SERVER['REQUEST_METHOD']);

--- a/proxy/config.php
+++ b/proxy/config.php
@@ -122,8 +122,8 @@ $callbacks_enabled = false;
 
 $callbacks = [
   'sparkpost' => [
-    // 'secret' => '',
-    'request_method' => 'POST',
+    'secret' => '85c573b980c3c248f083f9ca6a175659',
+    'request_method' => 'POST', // single value or array
     'content_type' => 'application/json',
     'target_path' => 'civicrm/sparkpost/callback'
   ]

--- a/proxy/config.php
+++ b/proxy/config.php
@@ -103,3 +103,12 @@ $rest_allowed_actions = array(
   ),
 );
 
+$callbacks_enabled = false;
+
+$callbacks = [
+  'sparkpost' => [
+    // 'secret' => '',
+    'request_method' => 'POST',
+    'target_path' => 'civicrm/sparkpost/callback'
+  ]
+];

--- a/proxy/config.php
+++ b/proxy/config.php
@@ -124,6 +124,7 @@ $callbacks = [
   'sparkpost' => [
     // 'secret' => '',
     'request_method' => 'POST',
+    'content_type' => 'application/json',
     'target_path' => 'civicrm/sparkpost/callback'
   ]
 ];


### PR DESCRIPTION
This PR adds callback handling to CIviProxy.

Callbacks should be configured in the third party with a URL in the proxy in the following format:

`{$proxy_base}/callback.php?source=CALLBACK_KEY&secret=CALLBACK_SECRET`

Where:

* CALLBACK_KEY is a key of an array in the $callbacks array that defines a callback
* and CALLBACK_SECRET is the value of the `secret` key in the defined callback

Other validations you can define include

* The request method
* The expected content type
* The body (not yet implemented)

Some notes on the implementation:

1. The callback feature is turned on by setting `$callbacks_enabled` to `true`. This is a slightly different mechanism to other CiviProxy features that are turned on and off by the presence of a target url. I didn't think that made sense in this case as callbacks define multiple target urls. I appreciate that this isn't great for usability. It might be better to refactor how features are turned on and off but I didn't want to go there.

2. There is a `civiproxy_callback_validate_body()` function that *could* be used to validate the payload. I haven't implemented this but can see that you might want to if you are very security conscious. Not sure what the best way to validate that would be. Some form of json schema validation might work for most json based callbacks, though that would involved the inclusion of another library, and might get complicated if the service is posting lots of different flavours of callback.  Though this could be handled in a similar way to `$rest_allowed_actions` where we define a series of definitions per callback.  Another approach would be to allow users to define (or select a predefined) extra validation functions for callbacks.

3. At the moment, the only supported request methods are GET and POST. I think this covers 99% of callbacks thought I guess some might want to use DELETE or PUT or something else. We can extend it if so.

4. At the moment, I am using my own redirect functions specifically for callbacks - one for POST and one for GET. I wrote these because the `civiproxy_redirect()` did not handle the body of post requests (even when the method used was POST). @systopia - you may want to refactor `civiproxy_redirect` so it can handle the body of post requests. Up to you how you want to handle it.

5. The CALLBACK_SECRET is another layer of security that I have implemented to allow the proxy to fail early.  This might interfere with callbacks that pass data via query params but in my experience these are few and far between (the CiviCRM rest API being a notable exception to the rule, and not good practice IMO, but nothing we have to worry about here since it is handled separately by the rest target).

5. Note that I did not add any IP restrictions. In my experience, these services are operating at 'cloud scale' and do not guarantee an originating IP. Instead they use methods like addings secrets/tokens to the http headers, etc.