### PR TITLE
simplify email regex; allow + in user part

### DIFF
--- a/proxy/proxy.php
+++ b/proxy/proxy.php
@@ -221,7 +221,7 @@ function civiproxy_sanitise($value, $type) {
     }
   } elseif ($type == 'email') {
     // valid email
-    if (!preg_match("#^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$#i", $value)) {
+    if (!preg_match("#^[_a-z0-9-]+[._a-z0-9-+]*@[a-z0-9-]+[.a-z0-9-]*\.[a-z]{2,3}$#i", $value)) {
       error_log("CiviProxy: removed invalid email parameter: " . $value);
       $value = '';
     }


### PR DESCRIPTION
Remove the grouping since it's not used.
Allow '+' in the user part after the first character.