### PR TITLE
Fix url references to preferred urls

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,13 +65,13 @@ You can set the URL of the target CiviCRM using the variable `$target_civirm` in
 ### Setting for the click tracking url
 There is a setting in CiviCRM which is used for tracking the clicks in your mailing. On your CiviProxy server this setting is captured in the variable `$target_url` in the `config.php` file:
 ```php
-$target_url       = $target_civicrm . '/sites/all/modules/civicrm/extern/url.php';
+$target_url       = $target_civicrm . '/civicrm/mailing/url';
 ```
 If you set it to the value NULL this functionality will not be available on your CiviProxy server.
 ### Setting for the open tracking
 CiviCRM tracks if a mailing has been opened in a certain way. CiviProxy has this setting in the variable `$target_open` in the `config.php` file:
 ```php
-$target_open      = $target_civicrm . '/sites/all/modules/civicrm/extern/open.php';
+$target_open      = $target_civicrm . '/civicrm/mailing/url/open.php';
 ```
 If you set it to the value NULL this functionality will not be available on your CiviProxy server.
 ### Setting for the location of images and included files in your mail(ing)

--- a/proxy/config.dist.php
+++ b/proxy/config.dist.php
@@ -63,7 +63,7 @@ $mail_subscription_user_key = NULL;
 $debug                      = NULL; //'LUXFbiaoz4dVWuAHEcuBAe7YQ4YP96rN4MCDmKj89p.log';
 
 // Local network interface or IP to be used for the relayed query
-// This is usefull in some VPN configurations (see CURLOPT_INTERFACE)
+// This is useful in some VPN configurations (see CURLOPT_INTERFACE)
 $target_interface           = NULL;
 
 /****************************************************************


### PR DESCRIPTION
The older urls are still commented in the config.dist.php file so should not
be too hard to find for someone dealing with an older site