### PR TITLE
Added SSL/TLS build steps to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,31 @@
-# You may find this Dockerfile useful in development or production
-# From the CiviProxy directory
-# * Build a docker image with `docker build . -t civiproxy`
-# * Run a development container with `run -d -p 4050:80 -v $PWD/proxy:/var/www/html --name civiproxy civiproxy`
+# Build: `docker build . -t civiproxy`
+# Run: `docker run -d -p 4050:4050 --name civiproxy civiproxy`
+# Browse: https://localhost:4050
 
+# This is a multi-stage build file. See https://docs.docker.com/develop/dev-best-practices/
+
+# Generate SSL/TLS cert and key.
+FROM debian:buster-slim AS cert_builder
+RUN apt update && apt install -y openssl
+RUN sed -i 's/^# subjectAltName=email:copy/subjectAltName=DNS:localhost/g' /etc/ssl/openssl.cnf
+RUN /usr/bin/openssl req \
+-subj '/CN=localhost/O=CiviProxyDev/C=UK' \
+-nodes \
+-new \
+-x509 \
+-newkey rsa:2048 \
+-keyout /etc/ssl/certs/civiproxy.key \
+-out /etc/ssl/certs/civiproxy.crt \
+-days 1095
+
+# Stand up CiviProxy
 FROM php:7-apache
-
+COPY --from=cert_builder /etc/ssl/certs/ /etc/ssl/certs/
 COPY proxy/ /var/www/html
+COPY civiproxy.ssl.conf /etc/apache2/sites-available/
+RUN a2enmod ssl
+RUN service apache2 restart
+RUN a2dissite 000-default.conf
+RUN a2dissite default-ssl.conf
+RUN a2ensite civiproxy.ssl.conf
+EXPOSE 4050

--- a/civiproxy.ssl.conf
+++ b/civiproxy.ssl.conf
@@ -1,0 +1,12 @@
+Listen 4050
+<VirtualHost _default_:4050>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/civiproxy.crt
+    SSLCertificateKeyFile /etc/ssl/certs/civiproxy.key
+</VirtualHost>


### PR DESCRIPTION
Looks like CiviProxy expects to run over SSL. 