### PR TITLE
Issue #39: added mosacio compatibility for wordpress

### DIFF
--- a/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
+++ b/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
@@ -59,6 +59,7 @@ class CRM_Civiproxy_Mailer {
     $value = preg_replace("#{$system_base}sites/all/modules/civicrm/extern/open.php#i", $proxy_base.'/open.php',        $value);
     $value = preg_replace("#{$system_base}sites/default/files/civicrm/persist/#i",      $proxy_base.'/file.php?id=',    $value);
     $value = preg_replace("#{$system_base}civicrm/mosaico/img\?src=#i",                 $proxy_base.'/mosaico.php?id=', $value);
+    $value = preg_replace("#{$system_base}civicrm/mosaico/img/\?src=#i",                 $proxy_base.'/mosaico.php?id=', $value);
 
     // Mailing related functions
     $value = preg_replace("#{$system_base}civicrm/mailing/view#i",                      $proxy_base.'/mailing/mail.php', $value);


### PR DESCRIPTION
**Before**

When sending a mailing with CiviCRM (and Mosaico) the urls for the images are not changed to the civi proxy url.
The url for mosaico images is `https://your-site/civicrm/mosaico/img/?src=` note the `/` after `img` 

**After**

When sending a mailing with CiviCRM (and Mosaico) the urls for the images are changed to the civi proxy url.

**Description**

In wordpress the mosaico image url contains a `/` after `img` and before `?src=`. The regex for searching for mosaico images did not cater for this.