### PR TITLE
Fix for #38

### DIFF
--- a/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
+++ b/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
@@ -62,7 +62,9 @@ class CRM_Civiproxy_Mailer {
     $value = preg_replace("#{$system_base}sites/default/files/civicrm/persist/#i",      $proxy_base.'/file.php?id=',    $value);
     $value = preg_replace("#{$system_base}civicrm/mosaico/img\?src=#i",                 $proxy_base.'/mosaico.php?id=', $value);
     if ($mosaico->isMosaicoInstalled()) {
-      $value = preg_replace("#({$mosaico->getMosaicoExtensionUrl()}/packages/mosaico/templates/)(\S*)([\"'])#i", $proxy_base . '/mosaico.php?template_url=$2$3', $value);
+      $value = preg_replace_callback("#({$mosaico->getMosaicoExtensionUrl()}/packages/mosaico/templates/)(\S*)([\"'])#i", function($matches) use ($proxy_base) {
+        return $proxy_base . '/mosaico.php?template_url=' . urlencode($matches[2]) . $matches[3];
+      }, $value);
     }
 
     // Mailing related functions

--- a/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
+++ b/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
@@ -61,6 +61,7 @@ class CRM_Civiproxy_Mailer {
     $value = preg_replace("#{$system_base}sites/all/modules/civicrm/extern/open.php#i", $proxy_base.'/open.php',        $value);
     $value = preg_replace("#{$system_base}sites/default/files/civicrm/persist/#i",      $proxy_base.'/file.php?id=',    $value);
     $value = preg_replace("#{$system_base}civicrm/mosaico/img\?src=#i",                 $proxy_base.'/mosaico.php?id=', $value);
+    $value = preg_replace("#{$system_base}civicrm/mosaico/img/\?src=#i", $proxy_base.'/mosaico.php?id=', $value);
     if ($mosaico->isMosaicoInstalled()) {
       $value = preg_replace_callback("#({$mosaico->getMosaicoExtensionUrl()}/packages/mosaico/templates/)(\S*)([\"'])#i", function($matches) use ($proxy_base) {
         return $proxy_base . '/mosaico.php?template_url=' . urlencode($matches[2]) . $matches[3];

--- a/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
+++ b/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
@@ -47,6 +47,8 @@ class CRM_Civiproxy_Mailer {
     $enabled = CRM_Core_BAO_Setting::getItem('CiviProxy Settings', 'proxy_enabled');
     if (!$enabled) return;
 
+    $mosaico = CRM_Civiproxy_Mosaico::singleton();
+
     // get the URLs
     $config      = CRM_Core_Config::singleton();
     $system_base = $config->userFrameworkBaseURL;
@@ -59,6 +61,9 @@ class CRM_Civiproxy_Mailer {
     $value = preg_replace("#{$system_base}sites/all/modules/civicrm/extern/open.php#i", $proxy_base.'/open.php',        $value);
     $value = preg_replace("#{$system_base}sites/default/files/civicrm/persist/#i",      $proxy_base.'/file.php?id=',    $value);
     $value = preg_replace("#{$system_base}civicrm/mosaico/img\?src=#i",                 $proxy_base.'/mosaico.php?id=', $value);
+    if ($mosaico->isMosaicoInstalled()) {
+      $value = preg_replace("#({$mosaico->getMosaicoExtensionUrl()}/packages/mosaico/templates/)(\S*)([\"'])#i", $proxy_base . '/mosaico.php?template_url=$2$3', $value);
+    }
 
     // Mailing related functions
     $value = preg_replace("#{$system_base}civicrm/mailing/view#i",                      $proxy_base.'/mailing/mail.php', $value);

--- a/de.systopia.civiproxy/CRM/Civiproxy/Mosaico.php
+++ b/de.systopia.civiproxy/CRM/Civiproxy/Mosaico.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright (C) 2021  Jaap Jansma (jaap.jansma@civicoop.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+class CRM_Civiproxy_Mosaico {
+
+  /**
+   * @var CRM_Civiproxy_Mosaico
+   */
+  private static $singleton;
+
+  /**
+   * @var String
+   */
+  private $mosiacoExtenionUrl;
+
+  /**
+   * @var bool
+   */
+  private $isMosaicoInstalled = false;
+
+  private function __construct() {
+    try {
+      $mosaicoExt = civicrm_api3('Extension', 'getsingle', ['full_name' => "uk.co.vedaconsulting.mosaico"]);
+      $this->isMosaicoInstalled = true;
+      $this->mosiacoExtenionUrl = CRM_Mosaico_ExtensionUtil::url();
+    } catch (\Exception $ex) {
+      // Do nothing
+    }
+  }
+
+  /**
+   * @return CRM_Civiproxy_Mosaico
+   */
+  public static function singleton() {
+    if (!self::$singleton) {
+      self::$singleton = new CRM_Civiproxy_Mosaico();
+    }
+    return self::$singleton;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isMosaicoInstalled() {
+    return $this->isMosaicoInstalled;
+  }
+
+  /**
+   * @return string
+   */
+  public function getMosaicoExtensionUrl() {
+    return $this->mosiacoExtenionUrl;
+  }
+
+}

--- a/proxy/config.dist.php
+++ b/proxy/config.dist.php
@@ -43,6 +43,7 @@ $target_civicrm = 'https://your.civicrm.installation.org';
 $target_rest      = $target_civicrm . '/sites/all/modules/civicrm/extern/rest.php';
 $target_file      = $target_civicrm . '/sites/default/files/civicrm/persist/';
 $target_mosaico   = NULL; // (disabled by default): $target_civicrm . '/civicrm/mosaico/img?src=';
+$target_mosaico_template_url = NULL; // (disabled by default): $target_civicrm . '/wp-content/uploads/civicrm/ext/uk.co.vedaconsulting.mosaico/packages/mosaico/templates/';
 $target_mail_view = $target_civicrm . '/civicrm/mailing/view';
 $target_url       = $target_civicrm . '/civicrm/mailing/url';
 $target_open      = $target_civicrm . '/civicrm/mailing/open';


### PR DESCRIPTION
Fixes the replacement of the social media icons from Mosaico templates.
Requires additional configuration of civiproxy (a url to the mosiaco extension on your civicrm installation).