### PR TITLE
Fix for issue #55: view in browser link is broken

### DIFF
--- a/proxy/mailing/mail.php
+++ b/proxy/mailing/mail.php
@@ -17,7 +17,7 @@ if (!$target_mail_view) civiproxy_http_error("Feature disabled", 405);
 civiproxy_security_check('mail-view');
 
 // basic restraints
-$valid_parameters = array(  'id'   => 'int'  );
+$valid_parameters = array(  'id'   => 'int', 'cid' => 'int', 'cs' => 'string'  );
 $parameters = civiproxy_get_parameters($valid_parameters);
 
 // check if id specified


### PR DESCRIPTION
This fixes #55 where the view in browser link is broken.

**Before**

In a received bulk mail the view in browser link does not lead to a personalized mail in the browser. Instead you see the tokens e.g. Dear {contact.first_name} instead of Dear Jaap Jansma

**After**

In a received bulk mail the view in browser link does lead to a personalized mail in the browser. You see Dear Jaap Jansma.

**Cause** 

Civi Proxy did not pass on the parameters `cid` and `cs` from the url to CiviCRM. 