### PR TITLE
Api4

### DIFF
--- a/proxy/.htaccess
+++ b/proxy/.htaccess
@@ -1,0 +1,6 @@
+# Serve
+<IfModule mod_rewrite.c>
+  RewriteEngine on
+  RewriteCond %{REQUEST_URI} ^/civicrm/ajax/api4
+  RewriteRule ^civicrm/ajax/api4/([^/]*)/([^/]*) rest4.php?entity=$1&action=$2 [QSA,B]
+</IfModule>

--- a/proxy/checks.php
+++ b/proxy/checks.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * generates a CiviCRM REST API compliant error
+ * and ends processing
+ */
+function civiproxy_rest_error($message) {
+  $error = array( 'is_error'      => 1,
+                  'error_message' => $message);
+  // TODO: Implement header();
+  print json_encode($error);
+  exit();
+}
+
+/**
+ * Updates $credentials['api_key'] in-place, or displays an error if api key
+ * is missing or does not correspond to an entry in $api_key_map (which should
+ * be set in config.php).
+ * @param array $credentials
+ * @param array $api_key_map
+ */
+function civiproxy_map_api_key(array &$credentials, array $api_key_map) {
+  if (empty($credentials['api_key'])) {
+    civiproxy_rest_error("No API key given");
+  }
+  else {
+    if (isset($api_key_map[$credentials['api_key']])) {
+      $credentials['api_key'] = $api_key_map[$credentials['api_key']];
+    }
+    else {
+      civiproxy_rest_error("Invalid api key");
+    }
+  }
+}
+
+/**
+ * Updates $credentials['key'] in-place, or displays an error if site key
+ * is missing or does not correspond to an entry in $sys_key_map (which should
+ * be set in config.php).
+ * @param array $credentials
+ * @param array $sys_key_map
+ */
+function civiproxy_map_site_key(array &$credentials, array $sys_key_map) {
+  if (empty($credentials['key'])) {
+    civiproxy_rest_error("No site key given");
+  }
+  else {
+    if (isset($sys_key_map[$credentials['key']])) {
+      $credentials['key'] = $sys_key_map[$credentials['key']];
+    }
+	else {
+      civiproxy_rest_error("Invalid site key");
+    }
+  }
+}
+
+/**
+ * @param array $action should have both 'entity' and 'action' keys set
+ * @param array $rest_allowed_actions from config.php
+ * @return array
+ */
+function civiproxy_get_valid_parameters(array $action, array $rest_allowed_actions) {
+  // in release 0.4, allowed entity/actions per IP were introduced. To introduce backward compatibility,
+  // the previous test is still used when no 'all' key is found in the array
+  if (isset($rest_allowed_actions['all'])) {
+    // get valid key for the rest_allowed_actions
+    $valid_allowed_key = civiproxy_get_valid_allowed_actions_key($action, $rest_allowed_actions);
+    $valid_parameters = civiproxy_retrieve_api_parameters($valid_allowed_key, $action['entity'], $action['action'], $rest_allowed_actions);
+    if (!$valid_parameters) {
+      civiproxy_rest_error("Invalid entity/action.");
+    }
+  }
+  else {
+    if (isset($rest_allowed_actions[$action['entity']]) && isset($rest_allowed_actions[$action['entity']][$action['action']])) {
+      $valid_parameters = $rest_allowed_actions[$action['entity']][$action['action']];
+    }
+    else {
+      civiproxy_rest_error("Invalid entity/action.");
+    }
+  }
+  return $valid_parameters;
+}

--- a/proxy/config.dist.php
+++ b/proxy/config.dist.php
@@ -41,6 +41,8 @@ $target_civicrm = 'https://your.civicrm.installation.org';
 
 // default paths, override if you want. Set to NULL to disable
 $target_rest      = $target_civicrm . '/sites/all/modules/civicrm/extern/rest.php';
+// base URL for api4 calls. Will append entity and action path segments
+$target_rest4     = $target_civicrm . '/civicrm/ajax/api4/';
 $target_file      = $target_civicrm . '/sites/default/files/civicrm/persist/';
 $target_mosaico   = NULL; // (disabled by default): $target_civicrm . '/civicrm/mosaico/img?src=';
 $target_mosaico_template_url = NULL; // (disabled by default): $target_civicrm . '/wp-content/uploads/civicrm/ext/uk.co.vedaconsulting.mosaico/packages/mosaico/templates/';
@@ -75,6 +77,10 @@ $debug                      = NULL; //'LUXFbiaoz4dVWuAHEcuBAe7YQ4YP96rN4MCDmKj89
 // This is useful in some VPN configurations (see CURLOPT_INTERFACE)
 $target_interface           = NULL;
 
+
+/***************************************************************
+ **                Authentication Options                     **
+ ***************************************************************/
 // API and SITE keys (you may add keys here)
 $api_key_map = [
   'my_api_key'   => 'my_api_key',   // use this to allow API key
@@ -90,6 +96,19 @@ if (file_exists(dirname(__FILE__)."/secrets.php")) {
   // keys can also be stored in 'secrets.php'
   require "secrets.php";
 }
+
+// CiviCRM's API can authenticate with different flows
+// https://docs.civicrm.org/dev/en/latest/framework/authx/#flows
+// CiviProxy supports 'header', 'xheader', 'legacyrest', and 'param'.
+// These flows are supported for API4 but could be extended to API3.
+// $authx_internal_flow controls how CiviProxy sends credentials to CiviCRM, and
+// $authx_external_flow where CiviProxy looks for credentials on incoming requests.
+// The internal setting needs to have a single scalar value, but the
+// external setting can be an array of accepted flows.
+// There is no standard header for site key, so in both header and xheader
+// flows it uses X-Civi-Key
+$authx_internal_flow = 'header';
+$authx_external_flow = ['legacyrest'];
 
 
 /****************************************************************

--- a/proxy/rest.php
+++ b/proxy/rest.php
@@ -9,10 +9,10 @@
 
 require_once "config.php";
 require_once "proxy.php";
+require_once "checks.php";
 
 // see if REST API is enabled
 if (!$target_rest) civiproxy_http_error("Feature disabled", 405);
-
 
 // basic check
 if (!civiproxy_security_check('rest')) {
@@ -21,25 +21,9 @@ if (!civiproxy_security_check('rest')) {
 
 // check credentials
 $credentials = civiproxy_get_parameters(array('key' => 'string', 'api_key' => 'string'));
-if (empty($credentials['key'])) {
-  civiproxy_rest_error("No site key given");
-} else {
-  if (isset($sys_key_map[$credentials['key']])) {
-    $credentials['key'] = $sys_key_map[$credentials['key']];
-  } else {
-    civiproxy_rest_error("Invalid site key");
-  }
-}
 
-if (empty($credentials['api_key'])) {
-  civiproxy_rest_error("No API key given");
-} else {
-  if (isset($api_key_map[$credentials['api_key']])) {
-    $credentials['api_key'] = $api_key_map[$credentials['api_key']];
-  } else {
-    civiproxy_rest_error("Invalid api key");
-  }
-}
+civiproxy_map_site_key($credentials, $sys_key_map);
+civiproxy_map_api_key($credentials, $api_key_map);
 
 // check if the call itself is allowed
 $action = civiproxy_get_parameters(array('entity' => 'string', 'action' => 'string', 'version' => 'int', 'json' => 'int', 'sequential' => 'int'));
@@ -47,22 +31,7 @@ if (!isset($action['version']) || $action['version'] != 3) {
   civiproxy_rest_error("API 'version' information missing.");
 }
 
-// in release 0.4, allowed entity/actions per IP were introduced. To introduce backward compatibility,
-// the previous test is still used when no 'all' key is found in the array
-if (isset($rest_allowed_actions['all'])) {
-	// get valid key for the rest_allowed_actions
-	$valid_allowed_key = civiproxy_get_valid_allowed_actions_key($action, $rest_allowed_actions);
-  $valid_parameters = civiproxy_retrieve_api_parameters($valid_allowed_key, $action['entity'], $action['action'], $rest_allowed_actions);
-	if (!$valid_parameters) {
-		civiproxy_rest_error("Invalid entity/action.");
-	}
-} else {
-	if (isset($rest_allowed_actions[$action['entity']]) && isset($rest_allowed_actions[$action['entity']][$action['action']])) {
-		$valid_parameters = $rest_allowed_actions[$action['entity']][$action['action']];
-	} else {
-		civiproxy_rest_error("Invalid entity/action.");
-	}
-}
+$valid_parameters= civiproxy_get_valid_parameters($action, $rest_allowed_actions);
 
 // extract parameters and add credentials and action data
 $parameters = civiproxy_get_parameters($valid_parameters);
@@ -88,17 +57,3 @@ if ($rest_evaluate_json_parameter) {
 // finally execute query
 civiproxy_log($target_rest);
 civiproxy_redirect($target_rest, $parameters);
-
-
-/**
- * generates a CiviCRM REST API compliant error
- * and ends processing
- */
-function civiproxy_rest_error($message) {
-  $error = array( 'is_error'      => 1,
-                  'error_message' => $message);
-  // TODO: Implement
-  //header();
-  print json_encode($error);
-  exit();
-}

--- a/proxy/rest4.php
+++ b/proxy/rest4.php
@@ -1,0 +1,89 @@
+<?php
+/*--------------------------------------------------------+
+| SYSTOPIA CiviProxy                                      |
+|  a simple proxy solution for external access to CiviCRM |
+| Copyright (C) 2015-2021 SYSTOPIA                        |
+| Author: B. Endres (endres -at- systopia.de)             |
+| http://www.systopia.de/                                 |
++---------------------------------------------------------*/
+
+require_once "config.php";
+require_once "proxy.php";
+require_once "checks.php";
+
+// see if REST API is enabled
+if (!$target_rest4) {
+  civiproxy_http_error("Feature disabled");
+}
+$valid_flows = ['header', 'xheader', 'legacyrest', 'param'];
+$headers_by_flow = [
+ 'header' => ['HTTP_AUTHORIZATION', 'HTTP_X_CIVI_KEY'],
+ 'xheader' => ['HTTP_X_CIVI_AUTH', 'HTTP_X_CIVI_KEY'],
+ 'legacyrest' => [],
+ 'param' => [],
+];
+if (!in_array($authx_internal_flow, $valid_flows)) {
+  civiproxy_http_error("Invalid internal auth flow '$authx_internal_flow'", 500);
+}
+$headers_to_log = [];
+foreach ($authx_external_flow as $external_flow) {
+  if (!in_array($external_flow, $valid_flows)) {
+    civiproxy_http_error("Invalid external auth flow '$external_flow'", 500);
+  }
+  $headers_to_log = array_merge($headers_to_log, $headers_by_flow[$external_flow]);
+}
+
+// basic check
+if (!civiproxy_security_check('rest', TRUE, $headers_to_log)) {
+  civiproxy_rest_error("Access denied.");
+}
+
+$credentials = [];
+// Find credentials on the incoming request
+foreach ($authx_external_flow as $external_flow) {
+  switch($external_flow) {
+    case 'header':
+      $credentials['api_key'] = civiproxy_get_header('AUTHORIZATION', 'Bearer ');
+      $credentials['key'] = civiproxy_get_header('HTTP_X_CIVI_KEY');
+      break;
+    case 'xheader':
+      $credentials['api_key'] = civiproxy_get_header('X_CIVI_AUTH', 'Bearer ');
+      $credentials['key'] = civiproxy_get_header('HTTP_X_CIVI_KEY');
+      break;
+    case 'legacyrest':
+      $credentials = civiproxy_get_parameters(array('api_key' => 'string', 'key' => 'string'));
+      break;
+    case 'param':
+      $authx_credentials = civiproxy_get_parameters(array('_authx' => 'string', '_authxSiteKey' => 'string'));
+      if (!empty($authx_credentials['_authx'])) {
+        // Snip off leading 'Bearer ' or 'Bearer+'
+        if (substr($authx_credentials['_authx'], 0, 6) === 'Bearer') {
+          $credentials['api_key'] = substr($authx_credentials['_authx'], 7);
+        }
+      }
+      if (!empty($authx_credentials['_authxSiteKey'])) {
+        $credentials['key'] = $authx_credentials['_authxSiteKey'];
+      }
+      break;
+  }
+  if (!empty($credentials['api_key'])) {
+    break;
+  }
+}
+
+civiproxy_map_api_key($credentials, $api_key_map);
+if (!empty($credentials['key'])) {
+  civiproxy_map_site_key( $credentials, $sys_key_map);
+}
+
+// check if the call itself is allowed
+$action = civiproxy_get_parameters(array('entity' => 'string', 'action' => 'string'));
+
+$valid_parameters = civiproxy_get_valid_parameters($action, $rest_allowed_actions);
+
+// extract parameters and add action data
+$parameters = civiproxy_get_parameters($valid_parameters, json_decode($_REQUEST['params'], true));
+
+// finally execute query
+civiproxy_log($target_rest4);
+civiproxy_redirect4($target_rest4 . $action['entity'] . '/' . $action['action'] , $parameters, $credentials);


### PR DESCRIPTION
Add support for proxying APIv4 requests. The first patch involves some copy-pasting of API3 code, and the second patch extracts some common functions.  If this looks like the right approach I can add a patch to update the documentation.

Fixes #66 