### PR TITLE
Update Mailer.php to support WP images in mailings

### DIFF
--- a/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
+++ b/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
@@ -71,7 +71,7 @@ class CRM_Civiproxy_Mailer {
     $value = preg_replace("#{$system_base}civicrm/mailing/open#i",                      $proxy_base.'/open.php',        $value);
     $value = preg_replace("#{$system_base}sites/all/modules/civicrm/extern/open.php#i", $proxy_base.'/open.php',        $value);
     $value = preg_replace("#{$system_base}sites/default/files/civicrm/persist/#i",      $proxy_base.'/file.php?id=',    $value);
-    $value = preg_replace("#{$system_base}wp-content/uploads/civicrm/persist/contribute/images/uploads/static/#i",      $proxy_base.'/file.php?id=',    $value);
+    $value = preg_replace("#{$system_base}wp-content/uploads/civicrm/persist/#i",      $proxy_base.'/file.php?id=',    $value);
     $value = preg_replace("#{$system_base}civicrm/mosaico/img\?src=#i",                 $proxy_base.'/mosaico.php?id=', $value);
     $value = preg_replace("#{$system_base}civicrm/mosaico/img/\?src=#i",                $proxy_base.'/mosaico.php?id=', $value);
     if ($mosaico->isMosaicoInstalled()) {

--- a/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
+++ b/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
@@ -71,7 +71,7 @@ class CRM_Civiproxy_Mailer {
     $value = preg_replace("#{$system_base}civicrm/mailing/open#i",                      $proxy_base.'/open.php',        $value);
     $value = preg_replace("#{$system_base}sites/all/modules/civicrm/extern/open.php#i", $proxy_base.'/open.php',        $value);
     $value = preg_replace("#{$system_base}sites/default/files/civicrm/persist/#i",      $proxy_base.'/file.php?id=',    $value);
-    $value = preg_replace("#{$system_base}wp-content/uploads/civicrm/persist/#i",      $proxy_base.'/file.php?id=',    $value);
+    $value = preg_replace("#{$system_base}wp-content/uploads/civicrm/persist/#i",       $proxy_base.'/file.php?id=',    $value);
     $value = preg_replace("#{$system_base}civicrm/mosaico/img\?src=#i",                 $proxy_base.'/mosaico.php?id=', $value);
     $value = preg_replace("#{$system_base}civicrm/mosaico/img/\?src=#i",                $proxy_base.'/mosaico.php?id=', $value);
     if ($mosaico->isMosaicoInstalled()) {

--- a/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
+++ b/de.systopia.civiproxy/CRM/Civiproxy/Mailer.php
@@ -71,8 +71,9 @@ class CRM_Civiproxy_Mailer {
     $value = preg_replace("#{$system_base}civicrm/mailing/open#i",                      $proxy_base.'/open.php',        $value);
     $value = preg_replace("#{$system_base}sites/all/modules/civicrm/extern/open.php#i", $proxy_base.'/open.php',        $value);
     $value = preg_replace("#{$system_base}sites/default/files/civicrm/persist/#i",      $proxy_base.'/file.php?id=',    $value);
+    $value = preg_replace("#{$system_base}wp-content/uploads/civicrm/persist/contribute/images/uploads/static/#i",      $proxy_base.'/file.php?id=',    $value);
     $value = preg_replace("#{$system_base}civicrm/mosaico/img\?src=#i",                 $proxy_base.'/mosaico.php?id=', $value);
-    $value = preg_replace("#{$system_base}civicrm/mosaico/img/\?src=#i", $proxy_base.'/mosaico.php?id=', $value);
+    $value = preg_replace("#{$system_base}civicrm/mosaico/img/\?src=#i",                $proxy_base.'/mosaico.php?id=', $value);
     if ($mosaico->isMosaicoInstalled()) {
       $value = preg_replace_callback("#({$mosaico->getMosaicoExtensionUrl()}/packages/mosaico/templates/)(\S*)([\"'])#i", function($matches) use ($proxy_base) {
         return $proxy_base . '/mosaico.php?template_url=' . urlencode($matches[2]) . $matches[3];


### PR DESCRIPTION
In relation to #80 where images in Mosaico mailings are pulling from WP uploads directory.