### PR TITLE
Use POST requests for mailing action confirmations

### DIFF
--- a/proxy/mailing/confirm.php
+++ b/proxy/mailing/confirm.php
@@ -27,15 +27,20 @@ if (empty($parameters['sid'])) civiproxy_http_error("Missing/invalid parameter '
 if (empty($parameters['cid'])) civiproxy_http_error("Missing/invalid parameter 'cid'.");
 if (empty($parameters['h']))   civiproxy_http_error("Missing/invalid parameter 'h'.");
 
-// PERFORM UNSUBSCRIBE
-$group_query = civicrm_api3('MailingEventConfirm', 'create', 
-                          array( 'subscribe_id'   => $parameters['sid'],
-                                 'contact_id'     => $parameters['cid'],
-                                 'hash'           => $parameters['h'],
-                                 'api_key'        => $mail_subscription_user_key,
-                                ));
-if (!empty($group_query['is_error'])) {
-  civiproxy_http_error($group_query['error_message'], 500);
+// PERFORM SUBSCRIBE ON POST REQUEST
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $group_query = civicrm_api3('MailingEventConfirm', 'create',
+    array( 'subscribe_id'   => $parameters['sid'],
+      'contact_id'     => $parameters['cid'],
+      'hash'           => $parameters['h'],
+      'api_key'        => $mail_subscription_user_key,
+    ));
+  if (!empty($group_query['is_error'])) {
+    civiproxy_http_error($group_query['error_message'], 500);
+  }
+  else {
+    $success = TRUE;
+  }
 }
 ?>
 
@@ -49,6 +54,10 @@ if (!empty($group_query['is_error'])) {
     body {
       margin: 0;
       padding: 0;
+    }
+
+    .btn {
+      padding: 10px;
     }
 
     .container {
@@ -82,7 +91,17 @@ if (!empty($group_query['is_error'])) {
       <a href="https://www.systopia.de/"><?php echo $civiproxy_logo;?></a>
     </div>
     <div id="content" class="center">
-      <p>Thank you. You are now subscribed to the newsletter.</a>
+      <?php if (!empty($success)): ?>
+        <p>Thank you. You are now subscribed to the newsletter.</p>
+      <?php else: ?>
+        <p>Please confirm your newsletter subscription.</p>
+      <form method="post" action="">
+        <input type="hidden" name="sid" value="<?= htmlspecialchars($parameters['sid']) ?>">
+        <input type="hidden" name="cid" value="<?= htmlspecialchars($parameters['cid']) ?>">
+        <input type="hidden" name="h" value="<?= htmlspecialchars($parameters['h']) ?>">
+        <button type="submit" class="btn">Yes, subscribe</button>
+      </form>
+    <?php endif; ?>
     </div>
   </div>
  </body>

--- a/proxy/mailing/confirm.php
+++ b/proxy/mailing/confirm.php
@@ -11,30 +11,41 @@ ini_set('include_path', dirname(dirname(__FILE__)));
 require_once "proxy.php";
 
 // see if mail open tracking is enabled
-if (!$mail_subscription_user_key) civiproxy_http_error("Feature disabled", 405);
+if (!$mail_subscription_user_key) {
+  civiproxy_http_error("Feature disabled", 405);
+}
 
 // basic check
 civiproxy_security_check('mail-confirm');
 
 // basic restraints
-$valid_parameters = array(    'sid'          => 'int',
-                              'cid'          => 'int', 
-                              'h'            => 'string');
+$valid_parameters = [
+  'sid' => 'int',
+  'cid' => 'int',
+  'h' => 'string',
+];
 $parameters = civiproxy_get_parameters($valid_parameters);
 
 // check if parameters specified
-if (empty($parameters['sid'])) civiproxy_http_error("Missing/invalid parameter 'sid'.");
-if (empty($parameters['cid'])) civiproxy_http_error("Missing/invalid parameter 'cid'.");
-if (empty($parameters['h']))   civiproxy_http_error("Missing/invalid parameter 'h'.");
+if (empty($parameters['sid'])) {
+  civiproxy_http_error("Missing/invalid parameter 'sid'.");
+}
+if (empty($parameters['cid'])) {
+  civiproxy_http_error("Missing/invalid parameter 'cid'.");
+}
+if (empty($parameters['h'])) {
+  civiproxy_http_error("Missing/invalid parameter 'h'.");
+}
 
 // PERFORM SUBSCRIBE ON POST REQUEST
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $group_query = civicrm_api3('MailingEventConfirm', 'create',
-    array( 'subscribe_id'   => $parameters['sid'],
-      'contact_id'     => $parameters['cid'],
-      'hash'           => $parameters['h'],
-      'api_key'        => $mail_subscription_user_key,
-    ));
+    [
+      'subscribe_id' => $parameters['sid'],
+      'contact_id' => $parameters['cid'],
+      'hash' => $parameters['h'],
+      'api_key' => $mail_subscription_user_key,
+    ]);
   if (!empty($group_query['is_error'])) {
     civiproxy_http_error($group_query['error_message'], 500);
   }
@@ -47,9 +58,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 <!DOCTYPE html>
 <html>
- <head>
+<head>
   <meta charset="UTF-8">
-  <title>CiviProxy Version <?php echo $civiproxy_version;?></title>
+  <title>CiviProxy Version <?php echo $civiproxy_version; ?></title>
   <style type="text/css">
     body {
       margin: 0;
@@ -61,8 +72,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     .container {
-        position: relative;
-        width: 100%;
+      position: relative;
+      width: 100%;
     }
 
     .center {
@@ -82,27 +93,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       text-align: center;
       width: 462px;
     }
-    
+
   </style>
- </head>
- <body>
-  <div id="container">
-    <div id="info" class="center">
-      <a href="https://www.systopia.de/"><?php echo $civiproxy_logo;?></a>
-    </div>
-    <div id="content" class="center">
-      <?php if (!empty($success)): ?>
-        <p>Thank you. You are now subscribed to the newsletter.</p>
-      <?php else: ?>
-        <p>Please confirm your newsletter subscription.</p>
+</head>
+<body>
+<div id="container">
+  <div id="info" class="center">
+    <a href="https://www.systopia.de/"><?php echo $civiproxy_logo; ?></a>
+  </div>
+  <div id="content" class="center">
+    <?php if (!empty($success)): ?>
+      <p>Thank you. You are now subscribed to the newsletter.</p>
+    <?php else: ?>
+      <p>Please confirm your newsletter subscription.</p>
       <form method="post" action="">
-        <input type="hidden" name="sid" value="<?= htmlspecialchars($parameters['sid']) ?>">
-        <input type="hidden" name="cid" value="<?= htmlspecialchars($parameters['cid']) ?>">
-        <input type="hidden" name="h" value="<?= htmlspecialchars($parameters['h']) ?>">
+        <input type="hidden" name="sid"
+               value="<?= htmlspecialchars($parameters['sid']) ?>">
+        <input type="hidden" name="cid"
+               value="<?= htmlspecialchars($parameters['cid']) ?>">
+        <input type="hidden" name="h"
+               value="<?= htmlspecialchars($parameters['h']) ?>">
         <button type="submit" class="btn">Yes, subscribe</button>
       </form>
     <?php endif; ?>
-    </div>
   </div>
- </body>
+</div>
+</body>
 </html>

--- a/proxy/mailing/resubscribe.php
+++ b/proxy/mailing/resubscribe.php
@@ -27,15 +27,21 @@ if (empty($parameters['jid'])) civiproxy_http_error("Missing/invalid parameter '
 if (empty($parameters['qid'])) civiproxy_http_error("Missing/invalid parameter 'qid'.");
 if (empty($parameters['h']))   civiproxy_http_error("Missing/invalid parameter 'h'.");
 
-// PERFORM UNSUBSCRIBE
-$group_query = civicrm_api3('MailingEventResubscribe', 'create', 
-                          array( 'job_id'         => $parameters['jid'],
-                                 'event_queue_id' => $parameters['qid'],
-                                 'hash'           => $parameters['h'],
-                                 'api_key'        => $mail_subscription_user_key,
-                                ));
-if (!empty($group_query['is_error'])) {
-  civiproxy_http_error($group_query['error_message'], 500);
+// PERFORM RE-SUBSCRIBE ON POST REQUEST
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $group_query = civicrm_api3('MailingEventResubscribe', 'create',
+    [
+      'job_id' => $parameters['jid'],
+      'event_queue_id' => $parameters['qid'],
+      'hash' => $parameters['h'],
+      'api_key' => $mail_subscription_user_key,
+    ]);
+  if (!empty($group_query['is_error'])) {
+    civiproxy_http_error($group_query['error_message'], 500);
+  }
+  else {
+    $success = TRUE;
+  }
 }
 ?>
 
@@ -49,6 +55,10 @@ if (!empty($group_query['is_error'])) {
     body {
       margin: 0;
       padding: 0;
+    }
+
+    .btn {
+      padding: 10px;
     }
 
     .container {
@@ -82,7 +92,17 @@ if (!empty($group_query['is_error'])) {
       <a href="https://www.systopia.de/"><?php echo $civiproxy_logo;?></a>
     </div>
     <div id="content" class="center">
-      <p>Thank you. You've been re-subscribed to the newsletter.</a>
+      <?php if (!empty($success)): ?>
+        <p>Thank you. You've been re-subscribed to the newsletter.</p>
+      <?php else: ?>
+        <p>Please confirm your newsletter re-subscription.</p>
+        <form method="post" action="">
+          <input type="hidden" name="jid" value="<?= htmlspecialchars($parameters['jid']) ?>">
+          <input type="hidden" name="qid" value="<?= htmlspecialchars($parameters['qid']) ?>">
+          <input type="hidden" name="h" value="<?= htmlspecialchars($parameters['h']) ?>">
+          <button type="submit" class="btn">Yes, re-subscribe</button>
+        </form>
+      <?php endif; ?>
     </div>
   </div>
  </body>

--- a/proxy/mailing/resubscribe.php
+++ b/proxy/mailing/resubscribe.php
@@ -11,21 +11,31 @@ ini_set('include_path', dirname(dirname(__FILE__)));
 require_once "proxy.php";
 
 // see if mail open tracking is enabled
-if (!$mail_subscription_user_key) civiproxy_http_error("Feature disabled", 405);
+if (!$mail_subscription_user_key) {
+  civiproxy_http_error("Feature disabled", 405);
+}
 
 // basic check
 civiproxy_security_check('mail-resubscribe');
 
 // basic restraints
-$valid_parameters = array(    'jid'          => 'int',
-                              'qid'          => 'int', 
-                              'h'            => 'string');
+$valid_parameters = [
+  'jid' => 'int',
+  'qid' => 'int',
+  'h' => 'string',
+];
 $parameters = civiproxy_get_parameters($valid_parameters);
 
 // check if parameters specified
-if (empty($parameters['jid'])) civiproxy_http_error("Missing/invalid parameter 'jid'.");
-if (empty($parameters['qid'])) civiproxy_http_error("Missing/invalid parameter 'qid'.");
-if (empty($parameters['h']))   civiproxy_http_error("Missing/invalid parameter 'h'.");
+if (empty($parameters['jid'])) {
+  civiproxy_http_error("Missing/invalid parameter 'jid'.");
+}
+if (empty($parameters['qid'])) {
+  civiproxy_http_error("Missing/invalid parameter 'qid'.");
+}
+if (empty($parameters['h'])) {
+  civiproxy_http_error("Missing/invalid parameter 'h'.");
+}
 
 // PERFORM RE-SUBSCRIBE ON POST REQUEST
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -48,9 +58,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 <!DOCTYPE html>
 <html>
- <head>
+<head>
   <meta charset="UTF-8">
-  <title>CiviProxy Version <?php echo $civiproxy_version;?></title>
+  <title>CiviProxy Version <?php echo $civiproxy_version; ?></title>
   <style type="text/css">
     body {
       margin: 0;
@@ -62,8 +72,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     .container {
-        position: relative;
-        width: 100%;
+      position: relative;
+      width: 100%;
     }
 
     .center {
@@ -83,27 +93,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       text-align: center;
       width: 462px;
     }
-    
+
   </style>
- </head>
- <body>
-  <div id="container">
-    <div id="info" class="center">
-      <a href="https://www.systopia.de/"><?php echo $civiproxy_logo;?></a>
-    </div>
-    <div id="content" class="center">
-      <?php if (!empty($success)): ?>
-        <p>Thank you. You've been re-subscribed to the newsletter.</p>
-      <?php else: ?>
-        <p>Please confirm your newsletter re-subscription.</p>
-        <form method="post" action="">
-          <input type="hidden" name="jid" value="<?= htmlspecialchars($parameters['jid']) ?>">
-          <input type="hidden" name="qid" value="<?= htmlspecialchars($parameters['qid']) ?>">
-          <input type="hidden" name="h" value="<?= htmlspecialchars($parameters['h']) ?>">
-          <button type="submit" class="btn">Yes, re-subscribe</button>
-        </form>
-      <?php endif; ?>
-    </div>
+</head>
+<body>
+<div id="container">
+  <div id="info" class="center">
+    <a href="https://www.systopia.de/"><?php echo $civiproxy_logo; ?></a>
   </div>
- </body>
+  <div id="content" class="center">
+    <?php if (!empty($success)): ?>
+      <p>Thank you. You've been re-subscribed to the newsletter.</p>
+    <?php else: ?>
+      <p>Please confirm your newsletter re-subscription.</p>
+      <form method="post" action="">
+        <input type="hidden" name="jid"
+               value="<?= htmlspecialchars($parameters['jid']) ?>">
+        <input type="hidden" name="qid"
+               value="<?= htmlspecialchars($parameters['qid']) ?>">
+        <input type="hidden" name="h"
+               value="<?= htmlspecialchars($parameters['h']) ?>">
+        <button type="submit" class="btn">Yes, re-subscribe</button>
+      </form>
+    <?php endif; ?>
+  </div>
+</div>
+</body>
 </html>

--- a/proxy/mailing/unsubscribe.php
+++ b/proxy/mailing/unsubscribe.php
@@ -27,15 +27,21 @@ if (empty($parameters['jid'])) civiproxy_http_error("Missing/invalid parameter '
 if (empty($parameters['qid'])) civiproxy_http_error("Missing/invalid parameter 'qid'.");
 if (empty($parameters['h']))   civiproxy_http_error("Missing/invalid parameter 'h'.");
 
-// PERFORM UNSUBSCRIBE
-$group_query = civicrm_api3('MailingEventUnsubscribe', 'create', 
-                          array( 'job_id'         => $parameters['jid'],
-                                 'event_queue_id' => $parameters['qid'],
-                                 'hash'           => $parameters['h'],
-                                 'api_key'        => $mail_subscription_user_key,
-                                ));
-if (!empty($group_query['is_error'])) {
-  civiproxy_http_error($group_query['error_message'], 500);
+// PERFORM UNSUBSCRIBE ON POST REQUEST
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $group_query = civicrm_api3('MailingEventUnsubscribe', 'create',
+    [
+      'job_id' => $parameters['jid'],
+      'event_queue_id' => $parameters['qid'],
+      'hash' => $parameters['h'],
+      'api_key' => $mail_subscription_user_key,
+    ]);
+  if (!empty($group_query['is_error'])) {
+    civiproxy_http_error($group_query['error_message'], 500);
+  }
+  else {
+    $success = TRUE;
+  }
 }
 ?>
 
@@ -49,6 +55,10 @@ if (!empty($group_query['is_error'])) {
     body {
       margin: 0;
       padding: 0;
+    }
+
+    .btn {
+      padding: 10px;
     }
 
     .container {
@@ -82,7 +92,17 @@ if (!empty($group_query['is_error'])) {
       <a href="https://www.systopia.de/"><?php echo $civiproxy_logo;?></a>
     </div>
     <div id="content" class="center">
-      <p>Thank you. You have been successfully unsubscribed.</a>
+      <?php if (!empty($success)): ?>
+        <p>Thank you. You have been successfully unsubscribed.</p>
+      <?php else: ?>
+        <p>Please confirm your newsletter unsubscription.</p>
+        <form method="post" action="">
+          <input type="hidden" name="jid" value="<?= htmlspecialchars($parameters['jid']) ?>">
+          <input type="hidden" name="qid" value="<?= htmlspecialchars($parameters['qid']) ?>">
+          <input type="hidden" name="h" value="<?= htmlspecialchars($parameters['h']) ?>">
+          <button type="submit" class="btn">Yes, unsubscribe</button>
+        </form>
+      <?php endif; ?>
     </div>
   </div>
  </body>

--- a/proxy/mailing/unsubscribe.php
+++ b/proxy/mailing/unsubscribe.php
@@ -11,21 +11,31 @@ ini_set('include_path', dirname(dirname(__FILE__)));
 require_once "proxy.php";
 
 // see if mailing subscribe feature is enabled
-if (empty($mail_subscription_user_key)) civiproxy_http_error("Feature disabled", 405);
+if (empty($mail_subscription_user_key)) {
+  civiproxy_http_error("Feature disabled", 405);
+}
 
 // basic check
 civiproxy_security_check('mail-unsubscribe');
 
 // basic restraints
-$valid_parameters = array(    'jid'          => 'int',
-                              'qid'          => 'int', 
-                              'h'            => 'string');
+$valid_parameters = [
+  'jid' => 'int',
+  'qid' => 'int',
+  'h' => 'string',
+];
 $parameters = civiproxy_get_parameters($valid_parameters);
 
 // check if parameters specified
-if (empty($parameters['jid'])) civiproxy_http_error("Missing/invalid parameter 'jid'.");
-if (empty($parameters['qid'])) civiproxy_http_error("Missing/invalid parameter 'qid'.");
-if (empty($parameters['h']))   civiproxy_http_error("Missing/invalid parameter 'h'.");
+if (empty($parameters['jid'])) {
+  civiproxy_http_error("Missing/invalid parameter 'jid'.");
+}
+if (empty($parameters['qid'])) {
+  civiproxy_http_error("Missing/invalid parameter 'qid'.");
+}
+if (empty($parameters['h'])) {
+  civiproxy_http_error("Missing/invalid parameter 'h'.");
+}
 
 // PERFORM UNSUBSCRIBE ON POST REQUEST
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -48,9 +58,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 <!DOCTYPE html>
 <html>
- <head>
+<head>
   <meta charset="UTF-8">
-  <title>CiviProxy Version <?php echo $civiproxy_version;?></title>
+  <title>CiviProxy Version <?php echo $civiproxy_version; ?></title>
   <style type="text/css">
     body {
       margin: 0;
@@ -62,8 +72,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     .container {
-        position: relative;
-        width: 100%;
+      position: relative;
+      width: 100%;
     }
 
     .center {
@@ -83,27 +93,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       text-align: center;
       width: 462px;
     }
-    
+
   </style>
- </head>
- <body>
-  <div id="container">
-    <div id="info" class="center">
-      <a href="https://www.systopia.de/"><?php echo $civiproxy_logo;?></a>
-    </div>
-    <div id="content" class="center">
-      <?php if (!empty($success)): ?>
-        <p>Thank you. You have been successfully unsubscribed.</p>
-      <?php else: ?>
-        <p>Please confirm your newsletter unsubscription.</p>
-        <form method="post" action="">
-          <input type="hidden" name="jid" value="<?= htmlspecialchars($parameters['jid']) ?>">
-          <input type="hidden" name="qid" value="<?= htmlspecialchars($parameters['qid']) ?>">
-          <input type="hidden" name="h" value="<?= htmlspecialchars($parameters['h']) ?>">
-          <button type="submit" class="btn">Yes, unsubscribe</button>
-        </form>
-      <?php endif; ?>
-    </div>
+</head>
+<body>
+<div id="container">
+  <div id="info" class="center">
+    <a href="https://www.systopia.de/"><?php echo $civiproxy_logo; ?></a>
   </div>
- </body>
+  <div id="content" class="center">
+    <?php if (!empty($success)): ?>
+      <p>Thank you. You have been successfully unsubscribed.</p>
+    <?php else: ?>
+      <p>Please confirm your newsletter unsubscription.</p>
+      <form method="post" action="">
+        <input type="hidden" name="jid"
+               value="<?= htmlspecialchars($parameters['jid']) ?>">
+        <input type="hidden" name="qid"
+               value="<?= htmlspecialchars($parameters['qid']) ?>">
+        <input type="hidden" name="h"
+               value="<?= htmlspecialchars($parameters['h']) ?>">
+        <button type="submit" class="btn">Yes, unsubscribe</button>
+      </form>
+    <?php endif; ?>
+  </div>
+</div>
+</body>
 </html>


### PR DESCRIPTION
Hello everyone,

Since we would like to use the unsubscribe link instead of the unsubscribe email address, I took a look at the pages for handling mailing actions.

I noticed that the actions are triggered by a GET request. I understand the intention to make the process as simple as possible, but I find this unusual and would also like to point out an important problem:
Security scanners such as [Advanced Threat Protection](https://docs.microsoft.com/en-us/office365/servicedescriptions/office-365-advanced-threat-protection-service-description) (ATP) in Microsoft Office 365 scan incoming emails and the links they contain for threats. In doing so, the scanner could open an unsubscribe link. The scanner's GET request would immediately and unintentionally cancel the newsletter subscription.

That's why I think it makes more sense to confirm by clicking a button and sending a POST request.

## ~Side Quest~ Edit: [Already implemented](https://lab.civicrm.org/dev/core/-/wikis/CiviMail-One-Click-Unsubscribe)

~To make the unsubscribe functionality a little more user-friendly again, the email headers defined by the [RFC 8058](https://tools.ietf.org/html/rfc8058) standard for unsubscribe handling could be implemented in the CiviCRM core. Then some email clients (e.g. Gmail, Thunderbird) could continue to provide a one-click solution:~

```
List-Unsubscribe: https://newsletter.my-awesome.org/mailing/unsubscribe.php?reset=1&jid=xxxxx&qid=xxxxxxxx&h=xxxxxxxxxxxxx
List-Unsubscribe-Post: List-Unsubscribe=One-Click
```

~As far as I know, this implementation in the core would probably also require further adjustments in CiviProxy, as only the URLs in the mail body are exchanged.~