### PR TITLE
Fix a typo and a type check

### DIFF
--- a/src/Plugin/Logger/Data.php
+++ b/src/Plugin/Logger/Data.php
@@ -80,12 +80,12 @@ class Data {
       if (array_key_exists('action', $this->parameters)) {
         $this->action = $this->parameters['action'];
       } elseif (array_key_exists('action', $parameters)) {
-        $this->entity = $parameters['action'];
+        $this->action = $parameters['action'];
       }
       if (array_key_exists('version', $this->parameters)) {
         $this->apiVersion = $this->parameters['version'];
       } elseif (array_key_exists('version', $parameters)) {
-        $this->entity = $parameters['version'];
+        $this->apiVersion = $parameters['version'];
       }
       unset($this->parameters['action']);
       unset($this->parameters['entity']);

--- a/src/Plugin/Logger/Data.php
+++ b/src/Plugin/Logger/Data.php
@@ -72,14 +72,20 @@ class Data {
       else {
         $this->parameters = $parameters;
       }
-      if (array_key_exists('entity', $parameters)) {
+      if (array_key_exists('entity', $this->parameters)) {
+        $this->entity = $this->parameters['entity'];
+      } elseif (array_key_exists('entity', $parameters)) {
         $this->entity = $parameters['entity'];
       }
       if (array_key_exists('action', $this->parameters)) {
-        $this->action = $parameters['action'];
+        $this->action = $this->parameters['action'];
+      } elseif (array_key_exists('action', $parameters)) {
+        $this->entity = $parameters['action'];
       }
       if (array_key_exists('version', $this->parameters)) {
-        $this->apiVersion = $parameters['version'];
+        $this->apiVersion = $this->parameters['version'];
+      } elseif (array_key_exists('version', $parameters)) {
+        $this->entity = $parameters['version'];
       }
       unset($this->parameters['action']);
       unset($this->parameters['entity']);

--- a/src/Plugin/Logger/LoggerImplementation/FileSystemLogger.php
+++ b/src/Plugin/Logger/LoggerImplementation/FileSystemLogger.php
@@ -125,7 +125,9 @@ class FileSystemLogger implements LoggerInterface {
         $contents = '[' . $contents . ']';
       }
       $data = json_decode($contents, TRUE);
-      $return = array_merge($return, $data);
+      if (is_array($data)) {
+        $return = array_merge($return, $data);
+      }
 
       // Archive the log file.
       if ($archiveDirExists) {

--- a/src/Plugin/Logger/Plugin.php
+++ b/src/Plugin/Logger/Plugin.php
@@ -45,7 +45,7 @@ class Plugin implements PluginInterface {
    *
    * @return array
    */
-  public function getSubscribedEvents() {
+  public function getSubscribedEvents(): array {
     return [
       PrepareRedirectEvent::class => 'onPrepareRedirect',
       RedirectErrorEvent::class => 'onRedirectError',
@@ -58,7 +58,7 @@ class Plugin implements PluginInterface {
    *
    * @return array
    */
-  public function getApiActionDefinitions() {
+  public function getApiActionDefinitions(): array {
     return [
       'readlog' => ['invokeReadLog'],
     ];


### PR DESCRIPTION
This PR contains two minor issues:

1. There is a failure because the Logger Plugin does not have the exact function declaration as the parent class
2. A type check for is_array has been added. During testing we had a corrupt log file which broke the reading of the log files. 