### PR TITLE
Support JSON-encoded API request parameters

### DIFF
--- a/proxy/rest.php
+++ b/proxy/rest.php
@@ -25,7 +25,7 @@ civiproxy_map_site_key($credentials, $sys_key_map);
 civiproxy_map_api_key($credentials, $api_key_map);
 
 // check if the call itself is allowed
-$action = civiproxy_get_parameters(array('entity' => 'string', 'action' => 'string', 'version' => 'int', 'json' => 'int', 'sequential' => 'int'));
+$action = civiproxy_get_parameters(array('entity' => 'string', 'action' => 'string', 'version' => 'int', 'json' => 'string', 'sequential' => 'int'));
 if (!isset($action['version']) || $action['version'] != 3) {
   civiproxy_rest_error("API 'version' information missing.");
 }

--- a/src/Plugin/Logger/Data.php
+++ b/src/Plugin/Logger/Data.php
@@ -64,16 +64,14 @@ class Data {
     if (NULL !== $url) {
       $this->url = $url;
     }
+    $this->parameters = $parameters;
     if (is_array($parameters)) {
       if (array_key_exists('json', $parameters)) {
-        $this->isJsonRequest = TRUE;
+        $this->isJsonRequest = !empty($parameters['json']);
         $jsonData = json_decode($parameters['json'], TRUE);
         if (is_array($jsonData)) {
           $this->parameters = $jsonData;
         }
-      }
-      else {
-        $this->parameters = $parameters;
       }
       if (array_key_exists('entity', $this->parameters)) {
         $this->entity = $this->parameters['entity'];

--- a/src/Plugin/Logger/Data.php
+++ b/src/Plugin/Logger/Data.php
@@ -57,6 +57,8 @@ class Data {
 
   public ?int $apiVersion = 3;
 
+  public $isJsonRequest = FALSE;
+
   public function __construct(?string $url = NULL, ?array $parameters = NULL) {
     $this->date = date('Y-m-d H:i:s');
     if (NULL !== $url) {
@@ -64,6 +66,7 @@ class Data {
     }
     if (is_array($parameters)) {
       if (array_key_exists('json', $parameters)) {
+        $this->isJsonRequest = TRUE;
         $jsonData = json_decode($parameters['json'], TRUE);
         if (is_array($jsonData)) {
           $this->parameters = $jsonData;
@@ -131,10 +134,7 @@ class Data {
   }
 
   public function isJsonRequest(): ?bool {
-    if (!empty($this->parameters['json'])) {
-      return TRUE;
-    }
-    return FALSE;
+    return $this->isJsonRequest;
   }
 
   protected function sanitize() {


### PR DESCRIPTION
When calling rest.php and having the api call parameters in the json field. The validation fails as rest.php expects this to be an integer.
Whilst the Abstract Core (of CMRF) encodes the api parameters into the json field as `json={"api_action":"abc"}`

This is only problematic when wants to queue the call and send a response (which is possible since #90). At the issue is that it does not return an JSON response but an xml response.

**Steps to reproduce**

1. in config.php enable logging
2. In config.php also enable a queuing for the entity Form Processor and action getfields. E.g. 
```php
$loggerPluginConfiguration = [
  // redis
  'primaryLogger' => 'filesystem',
  'fallbackLogger' => null,
  'filesystem' => [
    'directory' =>  '/var/www/gate3/logs',
    'archive' =>  '/var/www/gate3/logs/archive',
    // Remove log files from archive after 90 days
    'keep_archive' => 90,
    'rotation' => [
      'enabled' => true,
      'max_calls_per_file' => 100,
      // 15 minutes
      'max_time_per_file' => 900,
    ],
  ],
  // List of api entities & action to log (or queue)
  'entities' => [
    [
      'entity' => 'FormProcessor',
      // Provide the name of the action or * means any action.
      'action' => 'getfields',
      // When this TRUE we do not connect to CiviCRM but we do log the call. Also provide a queueResponse
      'queueOnly' => FALSE,
      //'queueReponse' => ['is_error' => '0'],
    ],
    [
      'entity' => 'FormProcessor',
      // Provide the name of the action or * means any action.
      'action' => '*',
      // When this TRUE we do not connect to CiviCRM but we do log the call. Also provide a queueResponse
      'queueOnly' => TRUE,
      'queueReponse' => ['is_error' => 0],
    ],
  ]
];

```
3. Call the civi proxy with the following URL: `https://gate3.amnesty-international.be/rest.php?entity=FormProcessor&action=getfields&key=yoursitekey&api_key=yourapikey&version=3&json={%22api_action%22:%22petition_form%22}`

**Expected outpout**

A JSON output containting `{'is_error': 0}`

**Actual output**

The XML results. 