### PR TITLE
security: add htaccess and docs for config.php

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,11 +35,20 @@ In the screen print below you can see the CiviProxy Settings page with the value
 The CiviProxy server is the actual policeman that receives all requests and decides if they are allowed to send data to or retrieve data from CiviCRM. It consists of a series of scripts which you need to install on the server as explained in [Installing CiviProxy](installation.md).
 
 Once you have installed your CiviProxy server you need to complete a few configuration steps.
+
 ### The Config.php file
 
 The configuration of CiviProxy is mainly controlled with one PHP file called `config.php`. Create this file by copying or renaming the `config.dist.php` file.
 
 ![List of files on your CiviProxy server](img/file%20list%20proxy.png)
+
+It is recommended to move the `config.php` file outside of the webroot, to avoid accidentally exposing configuration or secrets. You can do this by moving the `config.php` file to your preferred destiation, and adding a new `config.php` file in the original location with the following contents:
+
+```
+<?php
+
+require_once "/path/to/config.php";
+```
 
 ### Configuring the URL of your CiviProxy server
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,4 +36,9 @@ See [Configuring CiviProxy](configuration.md) for futher settings you need to ma
 4. Create a `config.php` file using `config.dist.php` as a template.
 5. Run in your webspace the command `composer install`
 
+!!! note
+    It is possible and recommended to outsource secrets into a separate file outside of the document root. By default, a
+    .htaccess file is included in the proxy directory so `config.php` and `secrets.php` are not accidentally leaked. If
+    you are using an alternative webserver, you'll have to ensure these files are protected.
+
 See [Configuring CiviProxy](configuration.md) for details on what you need to include in the `config.php` file.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,4 +36,9 @@ See [Configuring CiviProxy](configuration.md) for futher settings you need to ma
 4. Create a `config.php` file using `config.dist.php` as a template.
 5. Run in your webspace the command `composer install`
 
+!!! note
+    It is possible and recommended to outsource secrets into a [separate file outside of the document root](configuration.md).
+    By default, a .htaccess file is included in the proxy directory so `config.php` and `secrets.php` are not accidentally leaked. If
+    you are using an alternative webserver, you'll have to ensure these files are protected.
+
 See [Configuring CiviProxy](configuration.md) for details on what you need to include in the `config.php` file.

--- a/proxy/.htaccess
+++ b/proxy/.htaccess
@@ -5,3 +5,15 @@ Options -Indexes
   RewriteCond %{REQUEST_URI} ^/civicrm/ajax/api4
   RewriteRule ^civicrm/ajax/api4/([^/]*)/([^/]*) rest4.php?entity=$1&action=$2 [QSA,B]
 </IfModule>
+
+<FilesMatch "(secrets|config).php">
+  <IfModule !authz_core_module>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
+
+# Apache 2.4+
+  <IfModule authz_core_module>
+    Require all denied
+  </IfModule>
+</FilesMatch>

--- a/proxy/.htaccess
+++ b/proxy/.htaccess
@@ -5,3 +5,11 @@ Options -Indexes
   RewriteCond %{REQUEST_URI} ^/civicrm/ajax/api4
   RewriteRule ^civicrm/ajax/api4/([^/]*)/([^/]*) rest4.php?entity=$1&action=$2 [QSA,B]
 </IfModule>
+
+<Files config.php>
+  Deny from all
+</Files>
+
+<Files secrets.php>
+  Deny from all
+</Files>


### PR DESCRIPTION
During an Apache update, mod-php might be disabled for a short while. This would cause php files to be served as normal text files, potentially leaking secrets. This commit adds .htaccess restrictions and documentation for this problem.