### PR TITLE
feat: add Docker for prod and development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 # You may find this Dockerfile useful in development or production
 # From the CiviProxy directory
-# * Build a docker image with `docker build . -t civiproxy`
-# * Run a development container with `run -d -p 4050:80 -v $PWD/proxy:/var/www/html --name civiproxy civiproxy`
+# See docs/installation.md for instructions
 
-FROM php:7-apache
+FROM composer AS build
 
-COPY proxy/ /var/www/html
+COPY . /app
+RUN composer install
+RUN composer dump-autoload
+
+FROM php:8-apache
+
+COPY --from=build /app/proxy /var/www/html
+COPY --from=build /app/vendor /var/www/vendor
+COPY --from=build /app/plugins /var/www/plugins

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
-## About
+# About
 CiviProxy is a tool to set up a security proxy server specifically for your CiviCRM instance. It uses whitelisting and parameter sanitation to allow only legitimate requests to pass through. 
+
 ## Documentation
 The documentation on CiviProxy can be found here: https://docs.civicrm.org/civiproxy/en/latest/
+
 ## We need your support
 This software is provided as Free and Open Source Software, and we are happy if you find it useful. However, we have put a lot of work into it (and continue to do so), much of it unpaid for. So if you benefit from our software, please consider making a financial contribution so we can continue to maintain and develop it further.
 
 If you are willing to support us in developing this tool, please send an email to info@systopia.de to get an invoice or agree a different payment method. Thank you! 
+
+## Development
+
+You can start local development by copying the `proxy/config.dist.php` file into `proxy/config.php` and editing
+accordingly.
+
+For plugins and dependencies, `composer` is used. Run `composer install` to install necessary dependencies.
+
+To work in a docker container, a docker-compose file is included. Run `docker compose up` to get development access to
+civiproxy at `http://localhost:8080`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  civiproxy:
+    image: php:8.4-apache
+    volumes:
+      - ./proxy:/var/www/html
+      - ./vendor:/var/www/vendor
+      - ./plugins:/var/www/plugins
+    ports:
+      - 8080:80

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,3 +37,12 @@ See [Configuring CiviProxy](configuration.md) for futher settings you need to ma
 5. Run in your webspace the command `composer install`
 
 See [Configuring CiviProxy](configuration.md) for details on what you need to include in the `config.php` file.
+
+## Installing via docker
+
+1. Create a `config.php` file using `config.dist.php` as a template.
+1. Build a docker image with `docker build . -t civiproxy`
+1. Run the resulting container with `docker run -d -p 8080:80 -v $CONFIG_PHP:/var/www/html/config.php --name civiproxy civiproxy`
+
+This will create a docker container listening on port 8080. It is recommended to put this container behind a reverse
+proxy for SSL handling.


### PR DESCRIPTION
This commit introduces a Dockerfile for a production-ready docker container, and a docker-compose file for local development.

It simplifies the setup, making it more robust in the process. Together with commit `45cd8b9b7370653f73e0b9bcd9389e7b6d2e78e0` this should make it harder to accidentally expose internals.

The local docker environment also ensures the same php dependency stack for all developers, and makes switching between versions easier.

A future upgrade could include a CiviCRM instance with the civiproxy extension installed and configured.