### PR TITLE
Fix for issue #104: Verify webhook by civicrm

### DIFF
--- a/proxy/config.dist.php
+++ b/proxy/config.dist.php
@@ -279,6 +279,20 @@ $_webhook2api = [
                 [["data", "object", "metadata", "email"],      ["email"]]
             ],
             "parameter_sanitation" => [],
+            "verify_request" => [
+              "enable" => FALSE, // SET to TRUE to enable verification of the request against a CiviCRM api.
+              "entity" => "HmacSignature", // This is an API from the CiviHMAC extension (https://lab.civicrm.org/extensions/civihmac)
+              "action" => "verify",
+              "parameters" => ["provider" => "example"],
+              "parameter_mapping" => [
+                [["HTTP_BODY"], ["body"]], // This will submit the body as string to CiviCRM
+                [["HTTP_HEADERS"], ["headers"]], // This will submit all headers to CiviCRM in the headers (will be submitted as an array)
+                // Or use the config below to specify which header should be sent to CiviCRM as a separate api key.
+                // [["HTTP_HEADERS", "x-ms-date"], ["x-ms-date"]],
+                // [["HTTP_HEADERS", "x-ms-conetnt-sha256"], ['x-ms-content-sha256']],
+                // [["HTTP_HEADERS", "Authorization"], ["authorization"]],
+              ],  
+            ],
         ]
     ]
 ];

--- a/proxy/config.dist.php
+++ b/proxy/config.dist.php
@@ -283,6 +283,7 @@ $_webhook2api = [
               "enable" => FALSE, // SET to TRUE to enable verification of the request against a CiviCRM api.
               "entity" => "HmacSignature", // This is an API from the CiviHMAC extension (https://lab.civicrm.org/extensions/civihmac)
               "action" => "verify",
+              "version" => 3, // Only version 3 is supported
               "parameters" => ["provider" => "example"],
               "parameter_mapping" => [
                 [["HTTP_BODY"], ["body"]], // This will submit the body as string to CiviCRM

--- a/proxy/proxy.php
+++ b/proxy/proxy.php
@@ -334,7 +334,7 @@ function civiproxy_mend_URLs(&$string) {
 function civiproxy_security_check($target, $quit=TRUE, $log_headers = []) {
   // verify that we're SSL encrypted
   if ($_SERVER['HTTPS'] != "on") {
-   // civiproxy_http_error("This CiviProxy installation requires SSL encryption.", 400);
+    civiproxy_http_error("This CiviProxy installation requires SSL encryption.", 400);
   }
 
   global $debug;

--- a/proxy/proxy.php
+++ b/proxy/proxy.php
@@ -334,7 +334,7 @@ function civiproxy_mend_URLs(&$string) {
 function civiproxy_security_check($target, $quit=TRUE, $log_headers = []) {
   // verify that we're SSL encrypted
   if ($_SERVER['HTTPS'] != "on") {
-    civiproxy_http_error("This CiviProxy installation requires SSL encryption.", 400);
+   // civiproxy_http_error("This CiviProxy installation requires SSL encryption.", 400);
   }
 
   global $debug;

--- a/proxy/webhook2api.php
+++ b/proxy/webhook2api.php
@@ -163,7 +163,7 @@ function webhook2api_processConfiguration($configuration, $post_input) {
   exit();
 }
 
-function webhook2api_verifyRequest(array $configuration, Request $request, string $post_input) {
+function webhook2api_verifyRequest(array $configuration, Request $request, string $post_input): bool {
   // compile API query
   $data['HTTP_HEADERS'] = $request->headers;
   $data['HTTP_BODY'] = $post_input;
@@ -178,7 +178,8 @@ function webhook2api_verifyRequest(array $configuration, Request $request, strin
       // set to target
       webhook2api_setValue($params, $target_path, $value);
     }
-  } else {
+  } 
+  else {
     return FALSE;
   }
 

--- a/proxy/webhook2api.php
+++ b/proxy/webhook2api.php
@@ -104,7 +104,7 @@ function webhook2api_processConfiguration($configuration, $post_input) {
 
   // Verify request
   if (!empty($configuration['verify_request']) && !empty($configuration['verify_request']['enable'])) {
-    $request = new Request($_GET, $_POST, $_FILES, $_SERVER, $_COOKIE);
+    $request = Request::create();
     $request_is_valid = webhook2api_verifyRequest($configuration, $request, $post_input);
     if (!$request_is_valid) {
       // The verifcation of the request failed.

--- a/proxy/webhook2api.php
+++ b/proxy/webhook2api.php
@@ -8,7 +8,10 @@
 +---------------------------------------------------------*/
 
 require_once "config.php";
+require_once "../vendor/autoload.php";
 require_once "proxy.php";
+
+use Systopia\CiviProxy\Api\Request;
 
 // first check if webhooks are enabled
 if (empty($webhook2api)) civiproxy_http_error("Feature disabled", 405);
@@ -99,6 +102,17 @@ function webhook2api_processConfiguration($configuration, $post_input) {
     }
   }
 
+  // Verify request
+  if (!empty($configuration['verify_request']) && !empty($configuration['verify_request']['enable'])) {
+    $request = new Request($_GET, $_POST, $_FILES, $_SERVER, $_COOKIE);
+    $request_is_valid = webhook2api_verifyRequest($configuration, $request, $post_input);
+    if (!$request_is_valid) {
+      // The verifcation of the request failed.
+      // So return an access denied.
+      return ["Access denied", 403];
+    }
+  }
+
   // default return code if everything goes according to plan
   $http_code = 200;
   // check if we have a json_array and react accordingly
@@ -147,6 +161,32 @@ function webhook2api_processConfiguration($configuration, $post_input) {
   }
   // all done
   exit();
+}
+
+function webhook2api_verifyRequest(array $configuration, Request $request, string $post_input) {
+  // compile API query
+  $data['HTTP_HEADERS'] = $request->headers;
+  $data['HTTP_BODY'] = $post_input;
+  $params = is_array($configuration['verify_request']['parameters']) ? $configuration['verify_request']['parameters'] : [];
+  if (!empty($configuration['verify_request']['parameter_mapping']) && is_array($configuration['verify_request']['parameter_mapping'])) {
+    foreach ($configuration['verify_request']['parameter_mapping'] as $mapping) {
+      $source_path = $mapping[0];
+      $target_path = $mapping[1];
+      // get value
+      $value = webhook2api_getValue($data, $source_path);
+
+      // set to target
+      webhook2api_setValue($params, $target_path, $value);
+    }
+  } else {
+    return FALSE;
+  }
+
+  $params['api_key'] = $configuration['api_key'];
+
+
+  $return = civicrm_api3($configuration['verify_request']['entity'], $configuration['verify_request']['action'], $params);
+  return array_key_exists('is_error', $return) && empty($return['is_error']);
 }
 
 

--- a/src/Api/Request.php
+++ b/src/Api/Request.php
@@ -28,9 +28,15 @@ class Request {
     $this->request = $request;
     $this->files = $files;
     $this->server = $server;
+    foreach(getallheaders() as $header => $headerValue) {
+      $this->headers[$header] = $headerValue;
+    }
     foreach ($server as $header => $headerValue) {
       if (stripos($header, 'HTTP_') === 0) {
-        $this->headers[substr($header, 5)] = $headerValue;
+        $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($header, 5)))));
+        if (!isset($this->headers[$key])) {
+          $this->headers[$key] = $headerValue;
+        }
       }
     }
     $this->cookies = $cookies;

--- a/src/Api/Request.php
+++ b/src/Api/Request.php
@@ -41,10 +41,7 @@ class Request {
     $this->server = $server;
     foreach ($server as $header => $headerValue) {
       if (stripos($header, 'HTTP_') === 0) {
-        $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($header, 5)))));
-        if (!isset($this->headers[$key])) {
-          $this->headers[$key] = $headerValue;
-        }
+        $this->headers[$header] = $headerValue;
       }
     }
     $this->cookies = $cookies;

--- a/src/Api/Request.php
+++ b/src/Api/Request.php
@@ -24,7 +24,14 @@ class Request {
   public array $cookies = [];
 
   public static function create(): Request {
-    return new Request($_GET, $_POST, $_FILES, $_SERVER, $_COOKIE);
+    $request = new Request($_GET, $_POST, $_FILES, $_SERVER, $_COOKIE);
+    // We use getallheaders because it could be that not
+    // all headers are set in $_SERVER.
+    // For example the Authorization header.
+    foreach(getallheaders() as $header => $headerValue) {
+      $request->headers[$header] = $headerValue;
+    }
+    return $request;
   }
 
   public function __construct(array $query, array $request = [], array $files = [], array $server = [], array $cookies = []) {
@@ -32,12 +39,6 @@ class Request {
     $this->request = $request;
     $this->files = $files;
     $this->server = $server;
-    // We use getallheaders because it could be that not
-    // all headers are set in $_SERVER.
-    // For example the Authorization header.
-    foreach(getallheaders() as $header => $headerValue) {
-      $this->headers[$header] = $headerValue;
-    }
     foreach ($server as $header => $headerValue) {
       if (stripos($header, 'HTTP_') === 0) {
         $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($header, 5)))));

--- a/src/Api/Request.php
+++ b/src/Api/Request.php
@@ -23,6 +23,10 @@ class Request {
 
   public array $cookies = [];
 
+  public static function create(): Request {
+    return new Request($_GET, $_POST, $_FILES, $_SERVER, $_COOKIE);
+  }
+
   public function __construct(array $query, array $request = [], array $files = [], array $server = [], array $cookies = []) {
     $this->query = $query;
     $this->request = $request;

--- a/src/Api/Request.php
+++ b/src/Api/Request.php
@@ -32,6 +32,9 @@ class Request {
     $this->request = $request;
     $this->files = $files;
     $this->server = $server;
+    // We use getallheaders because it could be that not
+    // all headers are set in $_SERVER.
+    // For example the Authorization header.
     foreach(getallheaders() as $header => $headerValue) {
       $this->headers[$header] = $headerValue;
     }


### PR DESCRIPTION
This PR solves issue #104 

It adds the following functionality:
- ability to verify an incoming webhook request by civicrm. It does so to send an additional verification api to CiviCRM. The CiviCRM api succeeds or fails, if it succeeds the request is valid. If it fails the request is invalid

The reason for doing the verification in CiviCRM is that for HMAC verification we need a secret key to do the verification and we do not want to have too many secrets on the proxy. 

This PR also solves one bug with the Request class not containing all headers. 